### PR TITLE
Remove findBy of artifactClient.downloadArtifact

### DIFF
--- a/.github/workflows/ts.yaml
+++ b/.github/workflows/ts.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: ./
         with:
           test-files: 'tests/**/*.test.ts'
-          test-report-branch: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          test-report-branch: main
           test-report-artifact-name-prefix: test-report-
           shard-count: 2
       - run: cat "$SHARD_FILE"

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -84,6 +84,7 @@ const downloadTestReportArtifacts = async (
   core.info(`Filtered ${testReportArtifacts.length} artifacts of the test reports`)
 
   for (const testReportArtifact of testReportArtifacts) {
+    // TEST
     await core.group(`Downloading the artifact: ${testReportArtifact.name}`, () =>
       artifactClient.downloadArtifact(testReportArtifact.id, {
         path: path.join(inputs.testReportDirectory, `${workflowRunId}`, testReportArtifact.name),

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -84,7 +84,6 @@ const downloadTestReportArtifacts = async (
   core.info(`Filtered ${testReportArtifacts.length} artifacts of the test reports`)
 
   for (const testReportArtifact of testReportArtifacts) {
-    // TEST
     await core.group(`Downloading the artifact: ${testReportArtifact.name}`, () =>
       artifactClient.downloadArtifact(testReportArtifact.id, {
         path: path.join(inputs.testReportDirectory, `${workflowRunId}`, testReportArtifact.name),

--- a/src/artifact.ts
+++ b/src/artifact.ts
@@ -87,12 +87,6 @@ const downloadTestReportArtifacts = async (
     await core.group(`Downloading the artifact: ${testReportArtifact.name}`, () =>
       artifactClient.downloadArtifact(testReportArtifact.id, {
         path: path.join(inputs.testReportDirectory, `${workflowRunId}`, testReportArtifact.name),
-        findBy: {
-          workflowRunId: workflowRunId,
-          repositoryOwner: inputs.owner,
-          repositoryName: inputs.repo,
-          token: inputs.token,
-        },
       }),
     )
   }


### PR DESCRIPTION
## Problem to solve
When the artifact API returned 500 error, the artifact client does not retry it. This is because the artifact client uses a dedicated Octokit without retry plugin.
https://github.com/actions/toolkit/blob/1b1e81526b802d1d641911393281c2fb45ed5f11/packages/artifact/src/internal/download/download-artifact.ts#L131
