### PR TITLE
Support node --test JUnit reports

### DIFF
--- a/src/junitxml.ts
+++ b/src/junitxml.ts
@@ -45,32 +45,35 @@ export type TestCase = {
 
 export const findTestCasesFromJunitXml = (junitXml: JunitXml): TestCase[] => {
   const rootTestSuites: JunitXmlTestSuite[] = junitXml.testsuites?.testsuite ?? junitXml.testsuite ?? []
+  const rootTestCases: JunitXmlTestCase[] = junitXml.testsuites?.testcase ?? []
+
+  const determineTestCaseFilename = (junitXmlTestCase: JunitXmlTestCase): string => {
+    if (junitXmlTestCase['@_file']) {
+      return junitXmlTestCase['@_file']
+    }
+    // For Mocha or Cypress, the first <testsuite> element has the filename of the root suite.
+    const mochaRootSuiteFilename = rootTestSuites.at(0)?.['@_file']
+    if (mochaRootSuiteFilename) {
+      return mochaRootSuiteFilename
+    }
+    throw new Error(`Element <testcase> must have "file" attribute (name=${junitXmlTestCase['@_name']})`)
+  }
+
+  const toTestCase = (junitXmlTestCase: JunitXmlTestCase): TestCase => ({
+    filename: path.normalize(determineTestCaseFilename(junitXmlTestCase)),
+    time: junitXmlTestCase['@_time'],
+  })
 
   function* visit(testSuite: JunitXmlTestSuite): Generator<TestCase> {
-    const determineTestCaseFilename = (junitXmlTestCase: JunitXmlTestCase): string => {
-      if (junitXmlTestCase['@_file']) {
-        return junitXmlTestCase['@_file']
-      }
-      // For Mocha or Cypress, the first <testsuite> element has the filename of the root suite.
-      const mochaRootSuiteFilename = rootTestSuites.at(0)?.['@_file']
-      if (mochaRootSuiteFilename) {
-        return mochaRootSuiteFilename
-      }
-      throw new Error(`Element <testcase> must have "file" attribute (name=${junitXmlTestCase['@_name']})`)
-    }
-
     for (const junitXmlTestCase of testSuite.testcase ?? []) {
-      yield {
-        filename: path.normalize(determineTestCaseFilename(junitXmlTestCase)),
-        time: junitXmlTestCase['@_time'],
-      }
+      yield toTestCase(junitXmlTestCase)
     }
     for (const nestedTestSuite of testSuite.testsuite ?? []) {
       visit(nestedTestSuite)
     }
   }
 
-  const testCases: TestCase[] = []
+  const testCases: TestCase[] = rootTestCases.map(toTestCase)
   for (const testSuite of rootTestSuites) {
     for (const testCase of visit(testSuite)) {
       testCases.push(testCase)
@@ -114,6 +117,7 @@ const JunitXml = z.object({
   testsuites: z
     .object({
       testsuite: z.array(JunitXmlTestSuite).optional(),
+      testcase: z.array(JunitXmlTestCase).optional(),
     })
     .optional(),
   testsuite: z.array(JunitXmlTestSuite).optional(),

--- a/tests/junitxml.test.ts
+++ b/tests/junitxml.test.ts
@@ -78,6 +78,21 @@ describe('findTestCasesFromJunitXml', () => {
     ])
   })
 
+  it('should return node test root test cases', () => {
+    const junitXml = parseJunitXml(`<?xml version="1.0" encoding="utf-8"?>
+<testsuites>
+  <testcase name="test1" time="1" classname="test" file="src/a.test.ts"/>
+  <testcase name="test2" time="2" classname="test" file="./src/b.test.ts"/>
+  <testcase name="test3" time="3" classname="test" file="src/a.test.ts"/>
+</testsuites>`)
+
+    expect(findTestCasesFromJunitXml(junitXml)).toEqual<TestCase[]>([
+      { filename: 'src/a.test.ts', time: 1 },
+      { filename: 'src/b.test.ts', time: 2 },
+      { filename: 'src/a.test.ts', time: 3 },
+    ])
+  })
+
   it('should return test cases', () => {
     const junitXml = {
       testsuite: [

--- a/tests/junitxml.test.ts
+++ b/tests/junitxml.test.ts
@@ -41,6 +41,43 @@ describe('parseJunitXml', () => {
 })
 
 describe('findTestCasesFromJunitXml', () => {
+  it('should return test cases from a testsuites element', () => {
+    const junitXml = {
+      testsuites: {
+        testsuite: [
+          {
+            testcase: [
+              { '@_name': 'test1', '@_time': 1, '@_file': 'file1' },
+              { '@_name': 'test2', '@_time': 2, '@_file': 'file2' },
+            ],
+          },
+        ],
+      },
+    }
+    expect(findTestCasesFromJunitXml(junitXml)).toEqual<TestCase[]>([
+      { filename: 'file1', time: 1 },
+      { filename: 'file2', time: 2 },
+    ])
+  })
+
+  it('should use the root suite file when test cases do not have file attributes', () => {
+    const junitXml = {
+      testsuite: [
+        {
+          '@_file': 'spec/root_spec.rb',
+          testcase: [
+            { '@_name': 'test1', '@_time': 1 },
+            { '@_name': 'test2', '@_time': 2 },
+          ],
+        },
+      ],
+    }
+    expect(findTestCasesFromJunitXml(junitXml)).toEqual<TestCase[]>([
+      { filename: 'spec/root_spec.rb', time: 1 },
+      { filename: 'spec/root_spec.rb', time: 2 },
+    ])
+  })
+
   it('should return test cases', () => {
     const junitXml = {
       testsuite: [


### PR DESCRIPTION
## Purpose

Node.js `node --test --test-reporter=junit` emits `<testcase>` elements directly under the root `<testsuites>` element.

The current parser only reads test cases inside `<testsuite>` elements, so these reports are parsed successfully but produce 0 test cases. This prevents the action from using timing data from Node's built-in test runner.

## Changes

- Parse root-level `<testcase>` elements under `<testsuites>`.
- Keep the existing `<testsuite>` parsing and root suite `file` fallback behavior covered by tests.
- Add coverage for the Node.js JUnit report shape.

## Verification

I ran:

- `pnpm exec biome check src/junitxml.ts tests/junitxml.test.ts`
- `pnpm test --run`
- `pnpm build`
