### PR TITLE
Write workflow run summary in first shared only

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,10 @@ inputs:
     description: Name of the shards artifact
     required: true
     default: parallel-test-shards--${{ github.job }}
+  enable-summary:
+    description: (Internal) Whether to write the workflow run summary
+    required: false
+    default: ${{ strategy.job-index == 0 }}
   token:
     description: GitHub token
     required: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ const main = async () => {
       testReportBranch: core.getInput('test-report-branch', { required: true }),
       shardCount: parseInt(core.getInput('shard-count', { required: true }), 10),
       shardsArtifactName: core.getInput('shards-artifact-name', { required: true }),
+      enableSummary: core.getBooleanInput('enable-summary', { required: true }),
       token: core.getInput('token', { required: true }),
     },
     github.getOctokit(),

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,6 +21,7 @@ type Inputs = {
   testReportBranch: string
   shardCount: number
   shardsArtifactName: string
+  enableSummary: boolean
   token: string // downloadArtifact() of @actions/artifact requires a token
 }
 
@@ -53,11 +54,10 @@ export const run = async (inputs: Inputs, octokit: Octokit, context: Context): P
 
   const shardSet = distributeTestFilesToShards(workingTestFilenames, testFiles, inputs.shardCount)
   core.info(`Generated ${shardSet.shards.length} shards`)
-
-  const shardsLock = await writeShardsWithLock(shardSet.shards, shardsDirectory, inputs.shardsArtifactName)
-  if (shardsLock.currentJobAcquiredLock) {
+  if (inputs.enableSummary) {
     writeSummary(shardSet, testWorkflowRun)
   }
+  await writeShardsWithLock(shardSet.shards, shardsDirectory, inputs.shardsArtifactName)
 
   await ensureTestFilesConsistency(shardsDirectory, workingTestFilenames)
   return { shardsDirectory }

--- a/src/shard.ts
+++ b/src/shard.ts
@@ -125,15 +125,7 @@ export const tryDownloadShardsIfAlreadyExists = async (shardsDirectory: string, 
   return true
 }
 
-type Lock = {
-  currentJobAcquiredLock: boolean
-}
-
-export const writeShardsWithLock = async (
-  shards: Shard[],
-  shardsDirectory: string,
-  shardsArtifactName: string,
-): Promise<Lock> => {
+export const writeShardsWithLock = async (shards: Shard[], shardsDirectory: string, shardsArtifactName: string) => {
   const artifactClient = new DefaultArtifactClient()
 
   core.info(`Acquiring a lock of shards artifact`)
@@ -145,7 +137,7 @@ export const writeShardsWithLock = async (
   )
   if (!conflictError) {
     core.info(`This job successfully uploaded the shards. Others will download the shards.`)
-    return { currentJobAcquiredLock: true }
+    return
   }
 
   core.info(`Another job already uploaded the shards: ${conflictError}`)
@@ -156,7 +148,6 @@ export const writeShardsWithLock = async (
   await core.group(`Downloading the artifact: ${shardsArtifactName}`, () =>
     artifactClient.downloadArtifact(existingArtifact.artifact.id, { path: shardsDirectory }),
   )
-  return { currentJobAcquiredLock: false }
 }
 
 const catchHttp409ConflictError = async (f: () => Promise<void>): Promise<undefined | Error> => {


### PR DESCRIPTION
According to [the doc of upload-artifact](https://github.com/actions/upload-artifact#not-uploading-to-the-same-artifact), an artifact name must be unique. However, the artifact API sometimes accepts an artifact of the same name.

This changes the workflow run summary to be written only in the first shard.
